### PR TITLE
Fix UnboundLocalError

### DIFF
--- a/bin/k8s-topo
+++ b/bin/k8s-topo
@@ -357,7 +357,7 @@ class Device(object):
             full_link["local_intf"] = interface.replace("/", "_")
             full_link["local_ip"] = self.ips.get(interface, "")
 
-            my_endpoint = (self.name, interface, self.ips.get(interface, ""), _)
+            my_endpoint = (self.name, interface, self.ips.get(interface, ""),)
             peer_endpoints = [x for x in link.endpoints if x != my_endpoint]
             peer_name, peer_intf, peer_ip, _ = peer_endpoints.pop(0)
 


### PR DESCRIPTION
Using python 3.7, the following error occurs when trying to run k8s-topo.  This simple PR just fixes that error.

```
UnboundLocalError: local variable '_' referenced before assignment
```